### PR TITLE
fix: 마이페이지 배송정보에 불필요한 데이터 제거 및 배송지 정보 추가

### DIFF
--- a/src/main/webapp/WEB-INF/view/user/order-list.jsp
+++ b/src/main/webapp/WEB-INF/view/user/order-list.jsp
@@ -8,25 +8,20 @@
     <thead>
     <tr>
         <th>주문번호</th>
-        <th>회원ID/이메일</th>
         <th>총 금액</th>
-        <th>상태</th>
-        <th>상세 내용</th>
+        <th>배송 상태</th>
+        <th>배송지</th>
+<%--     필요하면 적용   <th>상세 페이지</th>--%>
     </tr>
     </thead>
     <tbody>
     <c:forEach var="order" items="${orders}">
         <tr>
             <td>${order.orderId}</td>
-            <td>
-                <c:choose>
-                    <c:when test="${not empty order.userId}">${order.userId}</c:when>
-                    <c:otherwise>${order.email}</c:otherwise>
-                </c:choose>
-            </td>
             <td><fmt:formatNumber value="${order.totalPrice}" type="number" groupingUsed="true"/>원</td>
             <td>${order.orderStatus}</td>
-            <td><a href="/orders/${order.orderId}">보기</a></td>
+            <td>${order.orderAddress}</td>
+<%--            <td><a href="/orders/${order.orderId}">보기</a></td>--%>
         </tr>
     </c:forEach>
     </tbody>


### PR DESCRIPTION
## 📌 과제 설명
- 마이페이지 주문 목록
## ✅ 피드백 반영사항
- 내 주문목록에서 불필요한 정보 제거(id, email)
- 배송지 정보 추가
- 주문 정보 상세 페이지 이동하는 이벤트 제거
